### PR TITLE
Fixing broken cmip link

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ R client for CMIP (Coupled Model Intercomparison Project) data
 
 Links:
 
-* CMIP (http://cmipr-pcmdi.llnl.gov/)
+* CMIP (http://cmip-pcmdi.llnl.gov/)
 * [CMIP Data available via FTP](http://gdo-dcp.ucllnl.org/downscaled_cmip_projections/dcpInterface.html#Projections:%20Complete%20Archives)
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ R client for CMIP (Coupled Model Intercomparison Project) data
 
 Links:
 
-* CMIP (http://cmipr-pcmdi.llnl.gov/)
+* CMIP (http://cmip-pcmdi.llnl.gov/)
 * [CMIP Data available via FTP](http://gdo-dcp.ucllnl.org/downscaled_cmip_projections/dcpInterface.html#Projections:%20Complete%20Archives)
 
 ## Install


### PR DESCRIPTION
Just changed `cmipr` to `cmip` in the URL for the CMIP data.